### PR TITLE
feat: add vault_keepalived_addr to allow changing vault addr

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,9 @@
 
 vault_keepalived_interface: ens192
 vault_keepalived_router_id: 25
-vault_keepalived_priority:  100
+vault_keepalived_priority: 100
 vault_keepalived_advert_int: 1
 vault_keepalived_auth_pass: "changeme"
 vault_keepalived_vip: 192.168.1.1
 vault_keepalived_group: "vault_keepalived"
-
+vault_keepalived_addr: "http://127.0.0.1:8200"

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -4,7 +4,7 @@ global_defs {
 }
 
 vrrp_script vault_active_node_script {
-  script       "/etc/keepalived/scripts/vault_active_node.py --timeout=1 --url='https://127.0.0.1:8200'"
+  script       "/etc/keepalived/scripts/vault_active_node.py --timeout=1 --url='{{ vault_keepalived_addr }}'"
   interval 2   # Run script every 2 seconds
   fall 1       # If script returns non-zero 2 times in succession, enter FAULT state
   rise 3       # If script returns zero r times in succession, exit FAULT state


### PR DESCRIPTION
There maybe cases, where the vault address differs from https://127.0.0.1:8200. Adding the variable vault_keepalived_addr would allow changing the vault address from outside of the role.